### PR TITLE
Make fittedImage and croppedImage work for URLs with spaces

### DIFF
--- a/src/Native/Element.js
+++ b/src/Native/Element.js
@@ -117,14 +117,14 @@ function plainImage(src)
 function tiledImage(src)
 {
 	var div = createNode('div');
-	div.style.backgroundImage = 'url(' + src + ')';
+	div.style.backgroundImage = 'url("' + src + '")';
 	return div;
 }
 
 function fittedImage(w, h, src)
 {
 	var div = createNode('div');
-	div.style.background = 'url(' + src + ') no-repeat center';
+	div.style.background = 'url("' + src + '") no-repeat center';
 	div.style.webkitBackgroundSize = 'cover';
 	div.style.MozBackgroundSize = 'cover';
 	div.style.OBackgroundSize = 'cover';


### PR DESCRIPTION
This issue was first opened (by @srikumarks) as an issue against `core`: https://github.com/elm-lang/core/issues/221, then addressed in a pull request: https://github.com/elm-lang/core/pull/222.

I have simply copied over to here, the change in one of the two files, as per Evan's comment: https://github.com/elm-lang/core/pull/222#issuecomment-218326529.
