### PR TITLE
Avoid use of realHtmlHeight when body is not yet loaded

### DIFF
--- a/src/Native/Element.js
+++ b/src/Native/Element.js
@@ -571,7 +571,7 @@ function block(align)
 }
 
 var htmlHeight =
-	typeof document !== 'undefined'
+	(typeof document !== 'undefined' && document.body)
 		? realHtmlHeight
 		: function(a, b) { return _elm_lang$core$Native_Utils.Tuple2(0, 0); };
 


### PR DESCRIPTION
`realHtmlHeight` adds nodes to document.body. Checking `typeof document !== 'undefined'` isn't enough; for scripts in the head document can be defined but `document.body` still be `null`

Fixes https://github.com/evancz/elm-graphics/issues/8 (which I also ran into)