### PR TITLE
Readd Native.Element.htmlHeight (still used by Text.width)

### DIFF
--- a/src/Native/Element.js
+++ b/src/Native/Element.js
@@ -607,6 +607,7 @@ return {
 	createNode: createNode,
 	newElement: F3(newElement),
 	addTransform: addTransform,
+	htmlHeight: F2(htmlHeight),
 
 	block: block
 };


### PR DESCRIPTION
Fixes https://github.com/evancz/elm-graphics/issues/3

`Native.Element.htmlHeight` was removed in 0182c58 , but it's still used by Text.width